### PR TITLE
fix: noticket - Add json field name hints for EmbedParms

### DIFF
--- a/authentication.go
+++ b/authentication.go
@@ -1,43 +1,48 @@
 package gr4vy
 
 import (
-	"fmt"
-	"github.com/golang-jwt/jwt"
-	"golang.org/x/crypto/ssh"
-	"time"
 	"crypto/ecdsa"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
-	"github.com/twinj/uuid"
+	"fmt"
 	"runtime"
+	"time"
+
+	"github.com/golang-jwt/jwt"
+	"github.com/twinj/uuid"
+	"golang.org/x/crypto/ssh"
 )
+
+func getEmbedClaims(embed EmbedParams) map[string]interface{} {
+	var inInterface map[string]interface{}
+	inrec, _ := json.Marshal(embed)
+	json.Unmarshal(inrec, &inInterface)
+
+	return inInterface
+}
 
 func getEmbedToken(private_key string, embed EmbedParams) (string, error) {
 	claims := jwt.MapClaims{
-		"iss": fmt.Sprintf("Gr4vy SDK %v - %v", VERSION, runtime.Version()), 
-		"nbf": float64(time.Now().Unix()),
-		"exp": float64(time.Now().Unix() + 3000),
+		"iss":    fmt.Sprintf("Gr4vy SDK %v - %v", VERSION, runtime.Version()),
+		"nbf":    float64(time.Now().Unix()),
+		"exp":    float64(time.Now().Unix() + 3000),
 		"scopes": []string{"embed"},
-		"jti": uuid.NewV4(),
+		"jti":    uuid.NewV4(),
 	}
 
-	var inInterface map[string]interface{}
-    inrec, _ := json.Marshal(embed)
-    json.Unmarshal(inrec, &inInterface)
-
-	claims["embed"] = inInterface
+	claims["embed"] = getEmbedClaims(embed)
 
 	return getTokenWithClaims(private_key, claims)
 }
 
 func getToken(private_key string, scopes []string) (string, error) {
 	claims := jwt.MapClaims{
-		"iss": fmt.Sprintf("Gr4vy SDK %v - %v", VERSION, runtime.Version()), 
-		"nbf": float64(time.Now().Unix()),
-		"exp": float64(time.Now().Unix() + 3000),
+		"iss":    fmt.Sprintf("Gr4vy SDK %v - %v", VERSION, runtime.Version()),
+		"nbf":    float64(time.Now().Unix()),
+		"exp":    float64(time.Now().Unix() + 3000),
 		"scopes": scopes,
-		"jti": uuid.NewV4(),
+		"jti":    uuid.NewV4(),
 	}
 
 	return getTokenWithClaims(private_key, claims)
@@ -45,7 +50,7 @@ func getToken(private_key string, scopes []string) (string, error) {
 
 func getTokenWithClaims(private_key string, claims jwt.MapClaims) (string, error) {
 	token := jwt.NewWithClaims(jwt.SigningMethodES512, claims)
-	
+
 	parsedKey, err := ssh.ParseRawPrivateKey([]byte(private_key))
 	if err != nil {
 		return "", err

--- a/gr4vy.go
+++ b/gr4vy.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/gr4vy/gr4vy-go/api"
 )
 
-const VERSION = "0.10.0"
+const VERSION = "0.11.0"
 
 type Gr4vyClient struct {
 	gr4vyId     string
@@ -25,10 +25,10 @@ type Gr4vyClient struct {
 }
 
 type EmbedParams struct {
-	Amount   int32				`json:"amount"`
-	Currency string				`json:"currency"`
-	BuyerID  string				`json:"buyer_id"`
-	Metadata map[string]string	`json:"metadata"`
+	Amount   int32             `json:"amount"`
+	Currency string            `json:"currency"`
+	BuyerID  string            `json:"buyer_id"`
+	Metadata map[string]string `json:"metadata"`
 }
 
 func NewGr4vyClient(gr4vy_id string, private_key string, environment string) *Gr4vyClient {

--- a/gr4vy.go
+++ b/gr4vy.go
@@ -25,10 +25,10 @@ type Gr4vyClient struct {
 }
 
 type EmbedParams struct {
-	Amount   int32
-	Currency string
-	BuyerID  string
-	Metadata map[string]string
+	Amount   int32				`json:"amount"`
+	Currency string				`json:"currency"`
+	BuyerID  string				`json:"buyer_id"`
+	Metadata map[string]string	`json:"metadata"`
 }
 
 func NewGr4vyClient(gr4vy_id string, private_key string, environment string) *Gr4vyClient {

--- a/gr4vy_test.go
+++ b/gr4vy_test.go
@@ -16,6 +16,19 @@ var paymentServiceId string
 var paymentServiceIdDelete string
 var transactionId string
 
+func TestEmbedClaimsSerialization(t *testing.T) {
+	embed := EmbedParams{
+		Amount:   200,
+		Currency: "USD",
+		BuyerID:  "d757c76a-cbd7-4b56-95a3-40125b51b29c",
+	}
+
+	serialized := getEmbedClaims(embed)
+
+	if _, present := serialized["buyer_id"]; !present {
+		t.Error("EmbedParams serialization is not snake_casing keys")
+	}
+}
 func TestEmbedToken(t *testing.T) {
 
 	key, err := GetKeyFromFile(keyPath)
@@ -31,6 +44,7 @@ func TestEmbedToken(t *testing.T) {
 		BuyerID:  "d757c76a-cbd7-4b56-95a3-40125b51b29c",
 		Metadata: map[string]string{"key": "value"},
 	}
+
 	_, err = client.GetEmbedToken(embed)
 
 	if err != nil {


### PR DESCRIPTION
Bug was introduced in v0.6.0 when moving from storing Embed params as a map to using EmbedParams; json.Marshal by default keeps case from the struct names. 