### PR TITLE
Add multi merchant header

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ func main() {
 In a multi-merchant environment, the merchant account ID can be set by using `NewGr4vyClientWithMid`:
 
 ```go
-  client := gr4vy.NewGr4vyClientWithMid("demo", key, "sandbox", "my_merchant_id")
+  client := gr4vy.NewGr4vyClientWithMid("demo", key, "sandbox", "my_merchant_account_id")
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ func main() {
 }
 ```
 
+## Multi merchant
+
+In a multi-merchant environment, the merchant account ID can be set by using `NewGr4vyClientWithMid`:
+
+```go
+  client := gr4vy.NewGr4vyClientWithMid("demo", key, "sandbox", "my_merchant_id")
+```
+
+
 ## Gr4vy Embed
 
 To create a token for Gr4vy Embed, call the `client.GetEmbedToken(embed)`

--- a/gr4vy.go
+++ b/gr4vy.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/gr4vy/gr4vy-go/api"
 )
 
-const VERSION = "0.23.0"
+const VERSION = "0.24.0"
 
 type Gr4vyClient struct {
 	gr4vyId     string

--- a/gr4vy.go
+++ b/gr4vy.go
@@ -22,6 +22,7 @@ type Gr4vyClient struct {
 	Debug       bool
 	accessToken string
 	environment string
+	merchantId string
 }
 
 type EmbedParams struct {
@@ -37,6 +38,18 @@ func NewGr4vyClient(gr4vy_id string, private_key string, environment string) *Gr
 		privateKey:  private_key,
 		Debug:       false,
 		environment: environment,
+		merchantId: "default",
+	}
+	return &client
+}
+
+func NewGr4vyClientWithMid(gr4vy_id string, private_key string, environment string, merchant_id string) *Gr4vyClient {
+	client := Gr4vyClient{
+		gr4vyId:     gr4vy_id,
+		privateKey:  private_key,
+		Debug:       false,
+		environment: environment,
+		merchantId: merchant_id,
 	}
 	return &client
 }
@@ -47,6 +60,7 @@ func NewGr4vyClientWithBaseUrl(base_url string, private_key string) *Gr4vyClient
 		baseUrl:     base_url,
 		Debug:       false,
 		environment: "sandbox",
+		merchantId: "default",
 	}
 	return &client
 }
@@ -67,6 +81,7 @@ func GetClient(c *Gr4vyClient) (*APIClient, error) {
 
 	config := NewConfiguration()
 	config.Servers[0].URL = c.BaseUrl()
+	config.AddDefaultHeader("X-GR4VY-MERCHANT-ACCOUNT-ID", c.merchantId)
 
 	client := NewAPIClient(config)
 

--- a/gr4vy.go
+++ b/gr4vy.go
@@ -22,7 +22,7 @@ type Gr4vyClient struct {
 	Debug       bool
 	accessToken string
 	environment string
-	merchantId string
+	merchantAccountId string
 }
 
 type EmbedParams struct {

--- a/gr4vy.go
+++ b/gr4vy.go
@@ -38,18 +38,18 @@ func NewGr4vyClient(gr4vy_id string, private_key string, environment string) *Gr
 		privateKey:  private_key,
 		Debug:       false,
 		environment: environment,
-		merchantId: "default",
+		merchantAccountId: "default",
 	}
 	return &client
 }
 
-func NewGr4vyClientWithMid(gr4vy_id string, private_key string, environment string, merchant_id string) *Gr4vyClient {
+func NewGr4vyClientWithMid(gr4vy_id string, private_key string, environment string, merchant_account_id string) *Gr4vyClient {
 	client := Gr4vyClient{
 		gr4vyId:     gr4vy_id,
 		privateKey:  private_key,
 		Debug:       false,
 		environment: environment,
-		merchantId: merchant_id,
+		merchantAccountId: merchant_account_id,
 	}
 	return &client
 }
@@ -60,7 +60,7 @@ func NewGr4vyClientWithBaseUrl(base_url string, private_key string) *Gr4vyClient
 		baseUrl:     base_url,
 		Debug:       false,
 		environment: "sandbox",
-		merchantId: "default",
+		merchantAccountId: "default",
 	}
 	return &client
 }
@@ -81,7 +81,7 @@ func GetClient(c *Gr4vyClient) (*APIClient, error) {
 
 	config := NewConfiguration()
 	config.Servers[0].URL = c.BaseUrl()
-	config.AddDefaultHeader("X-GR4VY-MERCHANT-ACCOUNT-ID", c.merchantId)
+	config.AddDefaultHeader("X-GR4VY-MERCHANT-ACCOUNT-ID", c.merchantAccountId)
 
 	client := NewAPIClient(config)
 

--- a/gr4vy_test.go
+++ b/gr4vy_test.go
@@ -117,6 +117,23 @@ func TestListBuyers(t *testing.T) {
 	}
 	t.Logf("%+v\n", *response)
 }
+
+func TestListBuyersForMid(t *testing.T) {
+	key, err := GetKeyFromFile(keyPath)
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+	client := NewGr4vyClientWithMid(gr4vyId, key, environment, "default")
+
+	var response *Gr4vyBuyers
+	response, _, err = client.ListBuyers(Int32(5))
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+	t.Logf("%+v\n", *response)
+}
 func TestListBuyersContext(t *testing.T) {
 	key, err := GetKeyFromFile(keyPath)
 	if err != nil {


### PR DESCRIPTION
Re TA-4184 - Adds an optional `merchantAccountId` prop to the client for use with multi merchant. This sets the `X-GR4VY-MERCHANT-ACCOUNT-ID` header and defaults to the `default` ID.