### PR TITLE
Add PostListPaymentOptions to SDK

### DIFF
--- a/gr4vy.go
+++ b/gr4vy.go
@@ -159,6 +159,11 @@ func String(v string) NullableString {
 	return *NewNullableString(&v)
 }
 
+
+func Gr4vyNullableInt32(v int32) NullableInt32 {
+	return *NewNullableInt32(&v)
+}
+
 func StringPtr(v string) *string {
 	return &v
 }

--- a/gr4vy_test.go
+++ b/gr4vy_test.go
@@ -350,6 +350,50 @@ func TestListPaymentOptionsContext(t *testing.T) {
 		return
 	}
 }
+func TestPostListPaymentOptions(t *testing.T) {
+	key, err := GetKeyFromFile(keyPath)
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+	client := NewGr4vyClient(gr4vyId, key, environment)
+
+	req := Gr4vyPaymentOptionsRequest{
+		Country:         String("GB"),
+		Currency:        String("GBP"),
+	}
+
+	var response *Gr4vyPaymentOptions
+	response, _, err = client.PostListPaymentOptions(req)
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+	var paymentOptionMethod = (*response.Items)[0].GetMethod()
+	t.Log("Retrieved payment options: " + paymentOptionMethod)
+}
+func TestPostListPaymentOptionsContext(t *testing.T) {
+	key, err := GetKeyFromFile(keyPath)
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+	client := NewGr4vyClient(gr4vyId, key, environment)
+
+	req := Gr4vyPaymentOptionsRequest{
+		Country:         String("GB"),
+		Currency:        String("GBP"),
+	}
+
+	var response *Gr4vyPaymentOptions
+	response, _, err = client.PostListPaymentOptionsContext(context.Background(), req)
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+	var paymentOptionMethod = (*response.Items)[1].GetMethod()
+	t.Log("Retrieved payment options: " + paymentOptionMethod)
+}
 
 func TestListPaymentServiceDefinitions(t *testing.T) {
 	key, err := GetKeyFromFile(keyPath)

--- a/gr4vy_test.go
+++ b/gr4vy_test.go
@@ -358,9 +358,17 @@ func TestPostListPaymentOptions(t *testing.T) {
 	}
 	client := NewGr4vyClient(gr4vyId, key, environment)
 
+	// cartItems := []CartItem{
+	// 	{Name: "Aloe", UnitAmount: 1000, Quantity: 1, Sku: String("aloe")},
+	// }
+
 	req := Gr4vyPaymentOptionsRequest{
-		Country:         String("GB"),
-		Currency:        String("GBP"),
+		Country:    String("US"),
+		Currency:   String("USD"),
+		Amount: 	Gr4vyNullableInt32(1000),
+		Metadata: 	map[string]string{"TypeOfPayment": "purchase", "Carbon_FootPrint": "10"},
+		// CartItems:	cartItems,
+		Locale:		String("en"),
 	}
 
 	var response *Gr4vyPaymentOptions
@@ -380,9 +388,17 @@ func TestPostListPaymentOptionsContext(t *testing.T) {
 	}
 	client := NewGr4vyClient(gr4vyId, key, environment)
 
+	// cartItems := []CartItem{
+	// 	{Name: "Aloe", UnitAmount: 1000, Quantity: 1, Sku: String("aloe")},
+	// }
+
 	req := Gr4vyPaymentOptionsRequest{
-		Country:         String("GB"),
-		Currency:        String("GBP"),
+		Country:    String("US"),
+		Currency:   String("USD"),
+		Amount: 	Gr4vyNullableInt32(1000),
+		Metadata: 	map[string]string{"TypeOfPayment": "purchase", "Carbon_FootPrint": "10"},
+		// CartItems:	cartItems,
+		Locale:		String("en"),
 	}
 
 	var response *Gr4vyPaymentOptions

--- a/sdk_payment_options.go
+++ b/sdk_payment_options.go
@@ -7,6 +7,7 @@ import (
 )
 
 type Gr4vyPaymentOptions PaymentOptions
+type Gr4vyPaymentOptionsRequest PaymentOptionsRequest
 
 func (c *Gr4vyClient) ListPaymentOptions() (*Gr4vyPaymentOptions, *http.Response, error) {
     client, err := GetClient(c)
@@ -35,6 +36,44 @@ func (c *Gr4vyClient) ListPaymentOptionsContext(ctx context.Context) (*Gr4vyPaym
     p := client.PaymentOptionsApi.ListPaymentOptions(auth)
     
     response, http, err := p.Execute()
+    c.HandleResponse(http, err)
+    if (err != nil) {
+        return nil, http, err
+    }
+    var r Gr4vyPaymentOptions = Gr4vyPaymentOptions(response)
+    return &r, http, err
+}
+func (c *Gr4vyClient) PostListPaymentOptions(body Gr4vyPaymentOptionsRequest) (*Gr4vyPaymentOptions, *http.Response, error) {
+    client, err := GetClient(c)
+    if err != nil {
+        return nil, nil, err
+    }
+
+    auth := context.WithValue(context.Background(), ContextAccessToken, c.accessToken)
+    p := client.PaymentOptionsApi.PostListPaymentOptions(auth)
+
+    var b PaymentOptionsRequest = PaymentOptionsRequest(body)
+    response, http, err := p.PaymentOptionsRequest(b).Execute()
+
+    c.HandleResponse(http, err)
+    if (err != nil) {
+        return nil, http, err
+    }
+    var r Gr4vyPaymentOptions = Gr4vyPaymentOptions(response)
+    return &r, http, err
+}
+func (c *Gr4vyClient) PostListPaymentOptionsContext(ctx context.Context, body Gr4vyPaymentOptionsRequest) (*Gr4vyPaymentOptions, *http.Response, error) {
+    client, err := GetClient(c)
+    if err != nil {
+        return nil, nil, err
+    }
+
+    auth := context.WithValue(ctx, ContextAccessToken, c.accessToken)
+    p := client.PaymentOptionsApi.PostListPaymentOptions(auth)
+
+    var b PaymentOptionsRequest = PaymentOptionsRequest(body)
+    response, http, err := p.PaymentOptionsRequest(b).Execute()
+
     c.HandleResponse(http, err)
     if (err != nil) {
         return nil, http, err


### PR DESCRIPTION
Needed so that support for the Post endpoint and the complicated 'cart_items' and 'metadata' can be sent via POST, instead of GET.