### PR TITLE
chore(tests): Add random response fields to ensure forward compatibility 

### DIFF
--- a/checkout_sessions_test.go
+++ b/checkout_sessions_test.go
@@ -51,7 +51,7 @@ func (i *jsonInterceptor) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	randomKey := fmt.Sprintf("unexpected_field_%d", rand.Intn(1000))
-	// This is where we add the unexpected field field
+	// This is where we add the unexpected field
 	data[randomKey] = "this is an injected test value"
 	modifiedBody, err := json.Marshal(data)
 	if err != nil {


### PR DESCRIPTION
Adds a test that can discover a forward compatibility issue early. We confirmed this was able to catch an issue with an older version of the Speakeasy generator. https://github.com/gr4vy/gr4vy-go/actions/runs/17436062142/job/49506123366