### PR TITLE
fix: zero-pad EC coordinates in JWK thumbprint (kid) — fixes 401 with valid key (TA-17136)

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -3,6 +3,7 @@ package gr4vygo
 import (
 	"context"
 	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
@@ -286,6 +287,13 @@ func withToken(privateKeyPEM string, scopes []JWTScope, expiresIn int, embedPara
 
 // calculateThumbprint calculates the RFC 7638 JWK thumbprint for the kid header
 func calculateThumbprint(privateKey *ecdsa.PrivateKey) (string, error) {
+	// The SDK signs with ES512, which mandates the P-521 curve. The JWK below
+	// hard-codes "crv": "P-521", so reject any other curve up front rather than
+	// emit a malformed JWK (crv mismatching the x/y size) and an incorrect kid.
+	if privateKey.Curve != elliptic.P521() {
+		return "", fmt.Errorf("unsupported curve %q: ES512 requires P-521", privateKey.Curve.Params().Name)
+	}
+
 	// RFC 7638 / RFC 7518 require the EC coordinates to be encoded as fixed-length
 	// octet strings, left-padded with zeros to the curve's byte size (66 bytes for
 	// P-521). big.Int.Bytes() strips leading zero bytes, which yields a shorter

--- a/auth.go
+++ b/auth.go
@@ -284,14 +284,26 @@ func withToken(privateKeyPEM string, scopes []JWTScope, expiresIn int, embedPara
 	}
 }
 
-// calculateThumbprint calculates the JWK thumbprint for the kid header
+// calculateThumbprint calculates the RFC 7638 JWK thumbprint for the kid header
 func calculateThumbprint(privateKey *ecdsa.PrivateKey) (string, error) {
+	// RFC 7638 / RFC 7518 require the EC coordinates to be encoded as fixed-length
+	// octet strings, left-padded with zeros to the curve's byte size (66 bytes for
+	// P-521). big.Int.Bytes() strips leading zero bytes, which yields a shorter
+	// encoding and therefore a different thumbprint whenever a coordinate's most
+	// significant byte is zero. That produced a kid the API could not match,
+	// resulting in 401 "No valid API authentication found". Pad with FillBytes.
+	coordLen := (privateKey.PublicKey.Curve.Params().BitSize + 7) / 8
+	xBytes := make([]byte, coordLen)
+	yBytes := make([]byte, coordLen)
+	privateKey.PublicKey.X.FillBytes(xBytes)
+	privateKey.PublicKey.Y.FillBytes(yBytes)
+
 	// Create JWK representation for ES512 (P-521 curve)
 	jwk := map[string]interface{}{
 		"kty": "EC",
 		"crv": "P-521",
-		"x":   base64.RawURLEncoding.EncodeToString(privateKey.PublicKey.X.Bytes()),
-		"y":   base64.RawURLEncoding.EncodeToString(privateKey.PublicKey.Y.Bytes()),
+		"x":   base64.RawURLEncoding.EncodeToString(xBytes),
+		"y":   base64.RawURLEncoding.EncodeToString(yBytes),
 	}
 
 	// Create canonical JSON (sorted keys, no spaces)

--- a/auth_test.go
+++ b/auth_test.go
@@ -89,6 +89,60 @@ func TestGetTokenCreatesValidSignedJWT(t *testing.T) {
 	}
 }
 
+// expectedKid is the RFC 7638 JWK thumbprint of testPrivateKeyPEM's public key,
+// computed independently (openssl + a standards-compliant JWK library) with the
+// EC coordinates zero-padded to the P-521 curve size. testPrivateKeyPEM's X
+// coordinate has a leading zero byte, so a thumbprint computed from the
+// unpadded big.Int.Bytes() representation would differ from this value — which
+// is exactly the bug that caused 401 "No valid API authentication found".
+const expectedKid = "va-SLs5AxJNfqKXD8LI5Y38BflpNvjZjY4RSWz66U1w"
+
+func TestGetTokenSetsCorrectKidHeader(t *testing.T) {
+	token, err := GetToken(testPrivateKeyPEM, []JWTScope{ReadAll, WriteAll}, 3600)
+	if err != nil {
+		t.Fatalf("Failed to create token: %v", err)
+	}
+
+	parsedToken, _, err := new(jwt.Parser).ParseUnverified(token, &TokenClaims{})
+	if err != nil {
+		t.Fatalf("Failed to parse token: %v", err)
+	}
+
+	kid, ok := parsedToken.Header["kid"].(string)
+	if !ok {
+		t.Fatalf("Expected kid header to be a string, got %v", parsedToken.Header["kid"])
+	}
+
+	if kid != expectedKid {
+		t.Errorf("Expected kid %q, got %q (EC coordinates must be zero-padded to the curve size)", expectedKid, kid)
+	}
+}
+
+func TestCalculateThumbprintZeroPadsCoordinates(t *testing.T) {
+	block, _ := pem.Decode([]byte(testPrivateKeyPEM))
+	privateKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		t.Fatalf("Failed to parse private key: %v", err)
+	}
+	ecdsaKey := privateKey.(*ecdsa.PrivateKey)
+
+	// Sanity check: this fixture exercises the bug — its X coordinate is shorter
+	// than the curve byte size, so it must be left-padded for a correct thumbprint.
+	coordLen := (ecdsaKey.PublicKey.Curve.Params().BitSize + 7) / 8
+	if len(ecdsaKey.PublicKey.X.Bytes()) >= coordLen {
+		t.Fatalf("test fixture no longer exercises the padding case: X is %d bytes, curve size is %d", len(ecdsaKey.PublicKey.X.Bytes()), coordLen)
+	}
+
+	thumbprint, err := calculateThumbprint(ecdsaKey)
+	if err != nil {
+		t.Fatalf("Failed to calculate thumbprint: %v", err)
+	}
+
+	if thumbprint != expectedKid {
+		t.Errorf("Expected thumbprint %q, got %q", expectedKid, thumbprint)
+	}
+}
+
 func TestGetTokenAcceptsOptionalEmbedData(t *testing.T) {
 	token, err := GetTokenWithEmbedProperties(testPrivateKeyPEM, []JWTScope{Embed}, 3600, testEmbedParams, "")
 	if err != nil {

--- a/auth_test.go
+++ b/auth_test.go
@@ -120,11 +120,17 @@ func TestGetTokenSetsCorrectKidHeader(t *testing.T) {
 
 func TestCalculateThumbprintZeroPadsCoordinates(t *testing.T) {
 	block, _ := pem.Decode([]byte(testPrivateKeyPEM))
+	if block == nil {
+		t.Fatal("Failed to decode test PEM block")
+	}
 	privateKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
 	if err != nil {
 		t.Fatalf("Failed to parse private key: %v", err)
 	}
-	ecdsaKey := privateKey.(*ecdsa.PrivateKey)
+	ecdsaKey, ok := privateKey.(*ecdsa.PrivateKey)
+	if !ok {
+		t.Fatalf("Test key is not ECDSA: %T", privateKey)
+	}
 
 	// Sanity check: this fixture exercises the bug — its X coordinate is shorter
 	// than the curve byte size, so it must be left-padded for a correct thumbprint.


### PR DESCRIPTION
## Summary

Fixes [TA-17136](https://gr4vy.atlassian.net/browse/TA-17136): the Go SDK returns `401 "No valid API authentication found"` with a valid private key that works fine in the Java SDK.

## Root cause

The SDK derives the JWT `kid` header from the **RFC 7638 JWK thumbprint** of the public key (`calculateThumbprint` in [`auth.go`](auth.go)). RFC 7638 (via RFC 7518) requires the EC coordinates `x` and `y` to be encoded as **fixed-length octet strings, left-padded with zeros** to the curve byte size (66 bytes for P-521).

The code used `privateKey.PublicKey.X.Bytes()`, and `big.Int.Bytes()` **strips leading zero bytes**. When a coordinate's most-significant byte is zero, the encoded coordinate is too short, so the SDK computes the *wrong* `kid`. The server registered the key under the correct (padded) thumbprint, can't match the SDK's `kid`, and rejects the request with a 401.

For P-521 the top coordinate byte is `0x00` roughly half the time, so **~75% of keys** (X or Y affected) hit this. The Java SDK delegates to Nimbus, which pads correctly — which is exactly why the same key worked there.

## Verification

Confirmed end-to-end with the repo's own test key (X coordinate is 65 bytes, one short of 66):

| | kid |
|---|---|
| Before (unpadded) | `QenAahZgqtd18krJO-0wCEGynQui8hy7DFYeNHeMLZI` |
| After (padded) | `va-SLs5AxJNfqKXD8LI5Y38BflpNvjZjY4RSWz66U1w` |

The "after" value was cross-checked with a fully independent toolchain (`openssl` + a pure-Python RFC 7638 implementation) and matches.

## Changes

- **`auth.go`** — `calculateThumbprint` now zero-pads `x`/`y` to the curve byte length using `big.Int.FillBytes` before base64url encoding.
- **`auth_test.go`** — added two regression tests pinning the `kid` / thumbprint to the correct value. The existing tests never asserted on `kid`, which is why this shipped unnoticed. The fixture deliberately exercises the leading-zero case.

## Notes for reviewers

- `auth.go` is a hand-maintained file (no Speakeasy `DO NOT EDIT` header), so the fix survives SDK regeneration.
- `go test .` passes (10 tests); `go build ./...` is clean.
- **Worth a follow-up:** the other gr4vy SDKs that hand-roll this thumbprint (Python, TypeScript, PHP, C#) likely have the same padding bug. Java is the only one confirmed correct because it uses Nimbus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TA-17136]: https://gr4vy.atlassian.net/browse/TA-17136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ