### PR TITLE
feat(auth): add getEmbedTokenWithCheckoutSession helper

### DIFF
--- a/.genignore
+++ b/.genignore
@@ -1,0 +1,2 @@
+auth.go
+auth_test.go

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ if err != nil {
 }
 ```
 
-> **Note:** This will only create a token once. Use `withToken` to dynamically generate a token
+> **Note:** This will only create a token once. Use `WithToken` to dynamically generate a token
 > for every request.
 
 ### Attaching a checkout session automatically

--- a/README.md
+++ b/README.md
@@ -147,6 +147,43 @@ if err != nil {
 > **Note:** This will only create a token once. Use `withToken` to dynamically generate a token
 > for every request.
 
+### Attaching a checkout session automatically
+
+For Embed, it is recommended to attach a checkout session to every transaction. The
+`GetEmbedTokenWithCheckoutSession` helper creates a checkout session using your SDK client and
+returns an Embed token with the resulting `checkout_session_id` already pinned, in a single call.
+
+```go
+import (
+	"context"
+	gr4vy "github.com/gr4vy/gr4vy-go"
+	"log"
+)
+
+privateKey := "...." // Private key loaded from disk or env var
+
+client := gr4vy.New(
+	gr4vy.WithID("example"),
+	gr4vy.WithServer(gr4vy.ServerSandbox),
+	gr4vy.WithSecuritySource(gr4vy.WithToken(privateKey, nil, 3600)),
+)
+
+embedParams := map[string]interface{}{
+	"amount":                    1299,
+	"currency":                  "USD",
+	"buyer_external_identifier": "user-1234",
+}
+
+token, err := gr4vy.GetEmbedTokenWithCheckoutSession(context.Background(), client, privateKey, embedParams, nil, nil)
+if err != nil {
+	log.Fatal(err)
+}
+```
+
+You can optionally pass a `*components.CheckoutSessionCreate` body to seed the session (for example
+with cart items or metadata), and a `*string` merchant account ID to override the client's
+configured merchant account.
+
 ## Merchant account ID selection
 
 Depending on the key used, you might need to explicitly define a merchant account ID to use. In our API, 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ privateKey := "...." // Private key loaded from disk or env var
 client := gr4vy.New(
 	gr4vy.WithID("example"),
 	gr4vy.WithServer(gr4vy.ServerSandbox),
-	gr4vy.WithSecuritySource(gr4vy.WithToken(privateKey, nil, 3600)),
+	gr4vy.WithSecuritySource(gr4vy.WithToken(privateKey, []gr4vy.JWTScope{gr4vy.CheckoutSessionsWrite}, 3600)),
 )
 
 embedParams := map[string]interface{}{

--- a/README.md
+++ b/README.md
@@ -144,8 +144,9 @@ if err != nil {
 }
 ```
 
-> **Note:** This will only create a token once. Use `WithToken` to dynamically generate a token
-> for every request.
+> **Note:** This will only create a token once. Call `GetEmbedToken` again whenever you need a
+> fresh Embed token (for example, once per page load). `WithToken` is for SDK API requests, not
+> Embed JWTs.
 
 ### Attaching a checkout session automatically
 

--- a/auth.go
+++ b/auth.go
@@ -232,12 +232,22 @@ func GetEmbedToken(privateKeyPEM string, embedParams map[string]interface{}, che
 //
 // Returns the signed JWT token string or an error.
 func GetEmbedTokenWithCheckoutSession(ctx context.Context, client *Gr4vy, privateKeyPEM string, embedParams map[string]interface{}, body *components.CheckoutSessionCreate, merchantAccountID *string) (string, error) {
+	if client == nil {
+		return "", fmt.Errorf("client is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	session, err := client.CheckoutSessions.Create(ctx, merchantAccountID, body)
 	if err != nil {
 		return "", fmt.Errorf("failed to create checkout session: %w", err)
 	}
+	if session == nil || session.ID == "" {
+		return "", fmt.Errorf("checkout session was created without an ID")
+	}
 
-	return getToken(privateKeyPEM, []JWTScope{Embed}, 3600, embedParams, session.ID)
+	return GetEmbedToken(privateKeyPEM, embedParams, session.ID)
 }
 
 // UpdateToken updates an existing JWT token with a new signature and optionally new data.

--- a/auth.go
+++ b/auth.go
@@ -219,6 +219,27 @@ func GetEmbedToken(privateKeyPEM string, embedParams map[string]interface{}, che
 	return getToken(privateKeyPEM, []JWTScope{Embed}, 3600, embedParams, checkoutSessionID)
 }
 
+// GetEmbedTokenWithCheckoutSession creates a checkout session using the provided
+// authenticated SDK client and returns an Embed token with the resulting checkout
+// session ID pinned. This is a convenience wrapper around GetEmbedToken for the
+// common Embed flow where every transaction should be tied to a checkout session.
+//   - ctx: Request context.
+//   - client: An authenticated Gr4vy SDK client.
+//   - privateKeyPEM: PEM-encoded ECDSA private key string.
+//   - embedParams: Optional map of embed parameters to include in the token.
+//   - body: Optional checkout session body to seed cart items, metadata, and so on. Pass nil for an empty session.
+//   - merchantAccountID: Optional merchant account ID override. Pass nil to use the client's configured one.
+//
+// Returns the signed JWT token string or an error.
+func GetEmbedTokenWithCheckoutSession(ctx context.Context, client *Gr4vy, privateKeyPEM string, embedParams map[string]interface{}, body *components.CheckoutSessionCreate, merchantAccountID *string) (string, error) {
+	session, err := client.CheckoutSessions.Create(ctx, merchantAccountID, body)
+	if err != nil {
+		return "", fmt.Errorf("failed to create checkout session: %w", err)
+	}
+
+	return getToken(privateKeyPEM, []JWTScope{Embed}, 3600, embedParams, session.ID)
+}
+
 // UpdateToken updates an existing JWT token with a new signature and optionally new data.
 //   - token: The existing JWT token string.
 //   - privateKeyPEM: PEM-encoded ECDSA private key string.

--- a/auth_test.go
+++ b/auth_test.go
@@ -324,6 +324,12 @@ func TestGetEmbedTokenWithCheckoutSessionNilClient(t *testing.T) {
 
 func TestGetEmbedTokenWithCheckoutSessionCreateFailure(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/checkout/sessions" {
+			t.Errorf("expected POST /checkout/sessions, got %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte(`{"type":"error","code":"internal_server_error","message":"boom"}`))
 	}))

--- a/auth_test.go
+++ b/auth_test.go
@@ -315,6 +315,46 @@ func TestGetEmbedTokenWithCheckoutSession(t *testing.T) {
 	}
 }
 
+func TestGetEmbedTokenWithCheckoutSessionNilClient(t *testing.T) {
+	_, err := GetEmbedTokenWithCheckoutSession(context.Background(), nil, testPrivateKeyPEM, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error for nil client, got nil")
+	}
+}
+
+func TestGetEmbedTokenWithCheckoutSessionCreateFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"type":"error","code":"internal_server_error","message":"boom"}`))
+	}))
+	defer server.Close()
+
+	client := New(WithServerURL(server.URL), WithSecurity("test-token"))
+	_, err := GetEmbedTokenWithCheckoutSession(context.Background(), client, testPrivateKeyPEM, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error on create failure, got nil")
+	}
+}
+
+func TestGetEmbedTokenWithCheckoutSessionEmptyID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/checkout/sessions" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"type":"checkout-session","id":""}`))
+	}))
+	defer server.Close()
+
+	client := New(WithServerURL(server.URL), WithSecurity("test-token"))
+	_, err := GetEmbedTokenWithCheckoutSession(context.Background(), client, testPrivateKeyPEM, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error for empty session ID, got nil")
+	}
+}
+
 func TestUpdateTokenResignsWithNewSignatureAndExpiration(t *testing.T) {
 	originalToken, err := GetToken(testPrivateKeyPEM, nil, 5)
 	if err != nil {

--- a/auth_test.go
+++ b/auth_test.go
@@ -345,6 +345,7 @@ func TestGetEmbedTokenWithCheckoutSessionCreateFailure(t *testing.T) {
 func TestGetEmbedTokenWithCheckoutSessionEmptyID(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/checkout/sessions" {
+			t.Errorf("expected POST /checkout/sessions, got %s %s", r.Method, r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
@@ -358,6 +359,9 @@ func TestGetEmbedTokenWithCheckoutSessionEmptyID(t *testing.T) {
 	_, err := GetEmbedTokenWithCheckoutSession(context.Background(), client, testPrivateKeyPEM, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for empty session ID, got nil")
+	}
+	if !strings.Contains(err.Error(), "without an ID") {
+		t.Errorf("expected error to mention missing ID, got: %v", err)
 	}
 }
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,9 +1,12 @@
 package gr4vygo
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/x509"
 	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -258,6 +261,51 @@ func TestGetEmbedTokenTakesOptionalCheckoutSessionID(t *testing.T) {
 
 	if claims.CheckoutSessionID != testCheckoutSessionID {
 		t.Errorf("Expected checkout_session_id %s, got %s", testCheckoutSessionID, claims.CheckoutSessionID)
+	}
+}
+
+func TestGetEmbedTokenWithCheckoutSession(t *testing.T) {
+	var createCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		createCalls++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"type":"checkout-session","id":"` + testCheckoutSessionID + `"}`))
+	}))
+	defer server.Close()
+
+	client := New(
+		WithServerURL(server.URL),
+		WithSecurity("test-token"),
+	)
+
+	token, err := GetEmbedTokenWithCheckoutSession(context.Background(), client, testPrivateKeyPEM, testEmbedParams, nil, nil)
+	if err != nil {
+		t.Fatalf("Failed to create embed token with checkout session: %v", err)
+	}
+
+	if createCalls != 1 {
+		t.Errorf("Expected checkout session create to be called once, got %d", createCalls)
+	}
+
+	parsedToken, err := jwt.ParseWithClaims(token, &TokenClaims{}, func(token *jwt.Token) (interface{}, error) {
+		block, _ := pem.Decode([]byte(testPrivateKeyPEM))
+		privateKey, _ := x509.ParsePKCS8PrivateKey(block.Bytes)
+		ecdsaKey := privateKey.(*ecdsa.PrivateKey)
+		return &ecdsaKey.PublicKey, nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to parse token: %v", err)
+	}
+
+	claims := parsedToken.Claims.(*TokenClaims)
+
+	if claims.CheckoutSessionID != testCheckoutSessionID {
+		t.Errorf("Expected checkout_session_id %s, got %s", testCheckoutSessionID, claims.CheckoutSessionID)
+	}
+
+	if len(claims.Scopes) != 1 || claims.Scopes[0] != string(Embed) {
+		t.Errorf("Expected embed scope, got %v", claims.Scopes)
 	}
 }
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -267,6 +267,12 @@ func TestGetEmbedTokenTakesOptionalCheckoutSessionID(t *testing.T) {
 func TestGetEmbedTokenWithCheckoutSession(t *testing.T) {
 	var createCalls int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Assert the SDK hits the intended endpoint, not just any request.
+		if r.Method != http.MethodPost || r.URL.Path != "/checkout/sessions" {
+			t.Errorf("expected POST /checkout/sessions, got %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
 		createCalls++
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)

--- a/test/flows/transaction_lifecycle_test.go
+++ b/test/flows/transaction_lifecycle_test.go
@@ -52,11 +52,15 @@ func TestCaptureListAndGet(t *testing.T) {
 		t.Fatalf("expected authorization_succeeded, got %s", tx.Status)
 	}
 
-	if _, err := m.Client.Transactions.Capture(ctx, operations.CaptureTransactionRequest{
+	captured, err := m.Client.Transactions.Capture(ctx, operations.CaptureTransactionRequest{
 		TransactionID:            tx.ID,
 		TransactionCaptureCreate: components.TransactionCaptureCreate{Amount: gr4vyInt(4500)},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("capture: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("capture returned nil response")
 	}
 
 	// Captures are eventually consistent; poll until one appears.

--- a/test/flows/transaction_lifecycle_test.go
+++ b/test/flows/transaction_lifecycle_test.go
@@ -64,13 +64,21 @@ func TestCaptureListAndGet(t *testing.T) {
 	}
 
 	// Captures are eventually consistent; poll until one appears.
+	var lastListErr error
 	captures, ok := harness.Until(30*time.Second, 2*time.Second,
 		func() (*components.CaptureCollection, error) {
-			return m.Client.Transactions.Captures.List(ctx, tx.ID, nil)
+			c, err := m.Client.Transactions.Captures.List(ctx, tx.ID, nil)
+			if err != nil {
+				lastListErr = err
+			}
+			return c, err
 		},
 		func(c *components.CaptureCollection) bool { return c != nil && len(c.Items) >= 1 },
 	)
 	if !ok || captures == nil || len(captures.Items) == 0 {
+		if lastListErr != nil {
+			t.Fatalf("expected at least one capture for the transaction (last error: %v)", lastListErr)
+		}
 		t.Fatal("expected at least one capture for the transaction")
 	}
 

--- a/test/flows/transaction_lifecycle_test.go
+++ b/test/flows/transaction_lifecycle_test.go
@@ -75,9 +75,15 @@ func TestCaptureListAndGet(t *testing.T) {
 	}
 
 	captureID := captures.Items[0].ID
+	if captureID == "" {
+		t.Fatal("capture item has an empty ID")
+	}
 	got, err := m.Client.Transactions.Captures.Get(ctx, tx.ID, captureID, nil)
 	if err != nil {
 		t.Fatalf("get capture: %v", err)
+	}
+	if got == nil {
+		t.Fatal("get capture returned nil response")
 	}
 	if got.ID != captureID {
 		t.Errorf("expected capture id %s, got %s", captureID, got.ID)

--- a/test/flows/transaction_lifecycle_test.go
+++ b/test/flows/transaction_lifecycle_test.go
@@ -5,6 +5,7 @@ package flows
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/gr4vy/gr4vy-go/models/components"
 	"github.com/gr4vy/gr4vy-go/models/operations"
@@ -39,6 +40,43 @@ func TestAuthorizeCaptureRefund(t *testing.T) {
 	}
 	if refund.ID == "" {
 		t.Fatal("refund id is empty")
+	}
+}
+
+func TestCaptureListAndGet(t *testing.T) {
+	m := harness.Merchant(t)
+	ctx := context.Background()
+
+	tx := harness.Authorize(t, m, 4500, "USD")
+	if tx.Status != components.TransactionStatusAuthorizationSucceeded {
+		t.Fatalf("expected authorization_succeeded, got %s", tx.Status)
+	}
+
+	if _, err := m.Client.Transactions.Capture(ctx, operations.CaptureTransactionRequest{
+		TransactionID:            tx.ID,
+		TransactionCaptureCreate: components.TransactionCaptureCreate{Amount: gr4vyInt(4500)},
+	}); err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+
+	// Captures are eventually consistent; poll until one appears.
+	captures, ok := harness.Until(30*time.Second, 2*time.Second,
+		func() (*components.CaptureCollection, error) {
+			return m.Client.Transactions.Captures.List(ctx, tx.ID, nil)
+		},
+		func(c *components.CaptureCollection) bool { return c != nil && len(c.Items) >= 1 },
+	)
+	if !ok || captures == nil || len(captures.Items) == 0 {
+		t.Fatal("expected at least one capture for the transaction")
+	}
+
+	captureID := captures.Items[0].ID
+	got, err := m.Client.Transactions.Captures.Get(ctx, tx.ID, captureID, nil)
+	if err != nil {
+		t.Fatalf("get capture: %v", err)
+	}
+	if got.ID != captureID {
+		t.Errorf("expected capture id %s, got %s", captureID, got.ID)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `GetEmbedTokenWithCheckoutSession` — a convenience helper that creates a checkout session via the authenticated SDK client and returns an Embed JWT with the resulting `checkout_session_id` pinned. This is the recommended one-call pattern for merchants who want every Embed transaction tied to a checkout session.
- Extends the offline unit tests to cover the happy path as well as all error branches (nil client, API failure, empty session ID).
- Adds `TestCaptureListAndGet` E2E test covering the previously untested `GET /transactions/{id}/captures` and `GET /transactions/{id}/captures/{capture_id}` endpoints.
- Adds `.genignore` to protect `auth.go` and `auth_test.go` from Speakeasy regeneration.
- Documents the helper in the README "Embed token generation" section.

## Test plan

- [ ] Offline tests: `go test ./... -run TestGetEmbedToken` (happy path + 3 error branches)
- [ ] E2E flows: `TestCaptureListAndGet` polls until captures appear then asserts list and get
- [ ] All CI checks green