### PR TITLE
ci: dispatch sdk_updated to gr4vy-cli on publish

### DIFF
--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -47,6 +47,7 @@ jobs:
       matrix:
         repo:
           - gr4vy/gr4vy-docs-mintlify
+          - gr4vy/gr4vy-cli
     runs-on: ubuntu-latest
     steps:
       - name: Notify SDKs


### PR DESCRIPTION
Adds `gr4vy/gr4vy-cli` to the `sdk_updated` `repository_dispatch` matrix in `sdk_publish.yaml`, alongside the docs repo.

## Why
The new Go CLI ([gr4vy/gr4vy-cli](https://github.com/gr4vy/gr4vy-cli)) generates its command surface from this SDK's types. Its `regen` workflow listens for `sdk_updated`; with this dispatch, a new SDK publish immediately triggers the CLI to bump `gr4vy-go`, regenerate, and open a draft PR. Without it, the CLI's daily cron still catches the update within ~24h — so this just makes it near-instant.

## Notes
- One-line addition to the existing dispatch matrix; uses the same `DISPATCH_ACCESS_TOKEN` already used for the docs dispatch. No new secrets.
- No effect on SDK publishing itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)