### PR TITLE
test: update List calls to request-struct signature

### DIFF
--- a/test/backoffice/payouts_test.go
+++ b/test/backoffice/payouts_test.go
@@ -5,12 +5,13 @@ import (
 	"testing"
 
 	"github.com/gr4vy/gr4vy-go/models/components"
+	"github.com/gr4vy/gr4vy-go/models/operations"
 	"github.com/gr4vy/gr4vy-go/test/harness"
 )
 
 func TestPayoutsList(t *testing.T) {
 	m := harness.Merchant(t)
-	if _, err := m.Client.Payouts.List(context.Background(), nil, nil, nil); err != nil {
+	if _, err := m.Client.Payouts.List(context.Background(), operations.ListPayoutsRequest{}); err != nil {
 		t.Fatalf("list payouts: %v", err)
 	}
 }

--- a/test/processing/payment_links_test.go
+++ b/test/processing/payment_links_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gr4vy/gr4vy-go/models/components"
+	"github.com/gr4vy/gr4vy-go/models/operations"
 	"github.com/gr4vy/gr4vy-go/test/harness"
 )
 
@@ -33,7 +34,7 @@ func TestPaymentLinkCRUD(t *testing.T) {
 		t.Fatalf("expected %s, got %s", link.ID, got.ID)
 	}
 
-	if _, err := m.Client.PaymentLinks.List(ctx, nil, nil, nil, nil); err != nil {
+	if _, err := m.Client.PaymentLinks.List(ctx, operations.ListPaymentLinksRequest{}); err != nil {
 		t.Fatalf("list payment links: %v", err)
 	}
 


### PR DESCRIPTION
## Why

`Generate SDK` has been failing since ~2026-06-24, blocking all SDK publishes. Root cause: the core OpenAPI spec added filter params to two list endpoints, crossing `maxMethodParams: 4` in `.speakeasy/gen.yaml`:

- `list_payouts`: 3 → **10** params
- `list_payment_links`: 4 → **13** params

Speakeasy now generates `Payouts.List` / `PaymentLinks.List` with a single request struct instead of positional args. The hand-written smoke tests still passed positional `nil`s, so regen's `Compile Tests` step failed:

```
test/backoffice/payouts_test.go:13: cannot use nil as operations.ListPayoutsRequest value in argument to m.Client.Payouts.List
test/processing/payment_links_test.go:36: cannot use nil as operations.ListPaymentLinksRequest value in argument to m.Client.PaymentLinks.List
```

That aborts the whole generation → nothing publishes.

## Change

Switch the two smoke tests to the request-struct form (`operations.ListPayoutsRequest{}` / `operations.ListPaymentLinksRequest{}`), matching every other large list op in the SDK.

## ⚠️ CI will be red on this PR

The committed SDK still has the **old flat** signatures (last successful regen predates the spec change), so `go build` / `go vet` here fail against the new test calls. This is expected — the fix only compiles once regen swaps the SDK. After merge, trigger `Generate SDK`: it regenerates the request-struct SDK, the (now-fixed) tests compile, and publishing resumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)