### PR TITLE
test: cover API key pairs and transaction refund-settlements endpoints

### DIFF
--- a/test/backoffice/api_key_pairs_test.go
+++ b/test/backoffice/api_key_pairs_test.go
@@ -1,0 +1,68 @@
+package backoffice
+
+import (
+	"context"
+	"testing"
+
+	gr4vygo "github.com/gr4vy/gr4vy-go"
+	"github.com/gr4vy/gr4vy-go/models/components"
+	"github.com/gr4vy/gr4vy-go/test/harness"
+)
+
+// API key pairs are an account-level resource, like merchant accounts: the
+// operations take no per-call merchant account id, so we drive them through the
+// shard's shared client directly (m.Client) rather than scoping a request to a
+// merchant account the way payment/transaction flows do.
+
+func TestApiKeyPairsList(t *testing.T) {
+	m := harness.Merchant(t)
+	// Happy path: listing needs no pre-existing resource, so it reaches a 2xx.
+	if _, err := m.Client.APIKeyPairs.List(context.Background(), nil, nil); err != nil {
+		t.Fatalf("list api key pairs: %v", err)
+	}
+}
+
+func TestApiKeyPairCreateIsReached(t *testing.T) {
+	m := harness.Merchant(t)
+	ctx := context.Background()
+
+	// Creating a usable key pair requires a real, existing role; the mock
+	// environment has none we can reference, so we point at a nonexistent role
+	// and assert the endpoint is reached and cleanly rejected (4xx).
+	harness.Reaches(t, "api_key_pairs.create", func() error {
+		_, err := m.Client.APIKeyPairs.Create(ctx, components.APIKeyPairCreate{
+			DisplayName: "E2E api key pair",
+			RoleIds:     []string{harness.MissingID},
+		})
+		return err
+	})
+}
+
+func TestApiKeyPairGetMissingIsReached(t *testing.T) {
+	m := harness.Merchant(t)
+	// No key pair with this id exists, so a fetch reaches the endpoint and is
+	// rejected with a 4xx — proving the SDK routes and serialises the request.
+	harness.Reaches(t, "api_key_pairs.get(missing)", func() error {
+		_, err := m.Client.APIKeyPairs.Get(context.Background(), harness.MissingID)
+		return err
+	})
+}
+
+func TestApiKeyPairUpdateMissingIsReached(t *testing.T) {
+	m := harness.Merchant(t)
+	// Updating a nonexistent key pair reaches the endpoint and is rejected (4xx).
+	harness.Reaches(t, "api_key_pairs.update(missing)", func() error {
+		_, err := m.Client.APIKeyPairs.Update(context.Background(), harness.MissingID, components.APIKeyPairUpdate{
+			DisplayName: gr4vygo.String("Updated"),
+		})
+		return err
+	})
+}
+
+func TestApiKeyPairDeleteMissingIsReached(t *testing.T) {
+	m := harness.Merchant(t)
+	// Deleting a nonexistent key pair reaches the endpoint and is rejected (4xx).
+	harness.Reaches(t, "api_key_pairs.delete(missing)", func() error {
+		return m.Client.APIKeyPairs.Delete(context.Background(), harness.MissingID)
+	})
+}

--- a/test/processing/transactions_test.go
+++ b/test/processing/transactions_test.go
@@ -74,6 +74,13 @@ func TestTransactionSubResources(t *testing.T) {
 		_, err := m.Client.Transactions.Settlements.Get(ctx, tx.ID, harness.MissingID, nil)
 		return err
 	})
+	if _, err := m.Client.Transactions.RefundSettlements.List(ctx, tx.ID, nil); err != nil {
+		t.Fatalf("list transaction refund settlements: %v", err)
+	}
+	harness.Reaches(t, "transactions.refund_settlements.get", func() error {
+		_, err := m.Client.Transactions.RefundSettlements.Get(ctx, tx.ID, harness.MissingID, nil)
+		return err
+	})
 }
 
 // TestTransactionCancelIsReached cancels a fresh authorization. Depending on


### PR DESCRIPTION
## The gap

CI's endpoint-coverage check counts an endpoint as covered only once a real HTTP request reaches the server. Two areas were uncovered:

1. The generated `APIKeyPairs` resource (`apikeypairs.go`) — List/Create/Get/Update/Delete had zero tests.
2. The transactions `RefundSettlements` sub-resource (`refundsettlements.go`) — List/Get had no tests (the coverage bot flagged `GET /transactions/{id}/refund-settlements` and `.../refund-settlements/{settlement_id}`).

## What this adds

### API key pairs — `test/backoffice/api_key_pairs_test.go` (new)
Package `backoffice`, mirroring the payouts/merchant-accounts conventions. API key pairs are an account-level resource (like merchant accounts) — no per-call merchant account id — so tests drive them through the shard's shared `m.Client` directly.

- **List** — happy path; asserts a clean 2xx.
- **Create / Get / Update / Delete** — `harness.Reaches(...)`: the mock environment can't produce a usable 2xx (create needs a real role; get/update/delete need an existing key pair), so we assert the endpoint is reached and cleanly rejected with a 4xx. Ids use `harness.MissingID`; Create references a nonexistent role via `RoleIds`.

### Transaction refund-settlements — `test/processing/transactions_test.go` (extended)
Added alongside the existing `settlements` coverage, mirroring its style exactly:

- **RefundSettlements.List** — happy path (like `settlements.list`).
- **RefundSettlements.Get(txn, MissingID)** — reached and cleanly rejected via `harness.Reaches` (like `settlements.get`).

## Verification

`go build ./...`, `go vet`, and `go test -c` all pass for both affected packages (`./test/backoffice/`, `./test/processing/`). The live suite was not run (needs sandbox credentials).