### PR TITLE
test: cover gift-card activations/issuances and authorization increment

### DIFF
--- a/test/processing/gift_cards_test.go
+++ b/test/processing/gift_cards_test.go
@@ -64,3 +64,40 @@ func TestGiftCardBalancesIsReached(t *testing.T) {
 		return err
 	})
 }
+
+// TestGiftCardActivationIsReached activates a gift card. Activation needs a
+// provisioned gift-card service, so we assert the endpoint is reached.
+func TestGiftCardActivationIsReached(t *testing.T) {
+	m := harness.Merchant(t)
+	ctx := context.Background()
+
+	pin := "1234"
+	amount := int64(1299)
+	currency := "USD"
+
+	harness.Reaches(t, "gift_cards.activations.create", func() error {
+		_, err := m.Client.GiftCards.Activations.Create(ctx, components.GiftCardActivationCreate{
+			Number:   "4111111111111111",
+			Pin:      &pin,
+			Amount:   &amount,
+			Currency: &currency,
+		}, nil, nil)
+		return err
+	})
+}
+
+// TestGiftCardIssuanceIsReached issues a new gift card. Issuance needs a
+// provisioned gift-card service with a theme, so we assert reach.
+func TestGiftCardIssuanceIsReached(t *testing.T) {
+	m := harness.Merchant(t)
+	ctx := context.Background()
+
+	harness.Reaches(t, "gift_cards.issuances.create", func() error {
+		_, err := m.Client.GiftCards.Issuances.Create(ctx, components.GiftCardIssuanceCreate{
+			Theme:    "default",
+			Amount:   1299,
+			Currency: "USD",
+		}, nil, nil)
+		return err
+	})
+}

--- a/test/processing/transactions_test.go
+++ b/test/processing/transactions_test.go
@@ -95,3 +95,19 @@ func TestTransactionCancelIsReached(t *testing.T) {
 		return err
 	})
 }
+
+// TestTransactionIncrementAuthorizationIsReached increments the authorization on
+// a fresh authorization. Incremental authorization is a PSP capability the mock
+// connector does not offer, so this may be cleanly rejected; either way it
+// reaches, and it is attempted against a genuinely authorized transaction.
+func TestTransactionIncrementAuthorizationIsReached(t *testing.T) {
+	m := harness.Merchant(t)
+	ctx := context.Background()
+	tx := harness.Authorize(t, m, 1299, "USD")
+
+	harness.Reaches(t, "transactions.increment_authorization", func() error {
+		_, err := m.Client.Transactions.IncrementAuthorization(ctx, tx.ID,
+			components.TransactionAuthorizationIncrementCreate{Amount: 500}, nil, nil)
+		return err
+	})
+}


### PR DESCRIPTION
## Why

The endpoint-reach report has been sitting at **116 / 119** on every SDK. The same three operations were never hitting the wire:

- `POST /gift-cards/activations`
- `POST /gift-cards/issuances`
- `POST /transactions/{transaction_id}/authorization/increment`

This closes the gap for Go. Companion PRs cover the other five SDKs.

## What

- `test/processing/gift_cards_test.go` — `TestGiftCardActivationIsReached`, `TestGiftCardIssuanceIsReached`
- `test/processing/transactions_test.go` — `TestTransactionIncrementAuthorizationIsReached`

All three need capabilities the mock-card merchant does not have (a configured gift-card service; a PSP that supports incremental authorization), so they follow the existing `harness.Reaches` convention: a 2xx or a clean 4xx passes, a **5xx fails**. The increment test authorizes a real transaction first, so the increment is attempted against a genuinely authorized transaction rather than a missing id.

## Verification

`gofmt`, `go vet` and `go build` are clean, and all three tests register with `go test -list`. I could not run the live suite locally (no sandbox signing key), so the `coverage` job on this PR is the verification — it should report **119 / 119**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)